### PR TITLE
version bump and dronification

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 pipeline:
   build:
-    image: docker:18.03
+    image: docker:stable
     environment:
       - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,37 @@
+pipeline:
+  build:
+    image: docker:18.03
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - docker build -t zookeeper .
+    when:
+      event: [push, tag]
+
+  image_to_quay:
+    image: quay.io/ukhomeofficedigital/drone-docker
+    secrets:
+      - docker_password
+    environment:
+      - DOCKER_USERNAME=ukhomeofficedigital+docker_zookeeper
+    registry: quay.io
+    repo: quay.io/ukhomeofficedigital/zookeeper
+    tags:
+      - ${DRONE_COMMIT_SHA}
+      - latest
+    when:
+      branch: master
+      event: push
+
+  tag_to_quay:
+    image: quay.io/ukhomeofficedigital/drone-docker
+    secrets:
+      - docker_password
+    environment:
+      - DOCKER_USERNAME=ukhomeofficedigital+docker_zookeeper
+    registry: quay.io
+    repo: quay.io/ukhomeofficedigital/zookeeper
+    tags:
+      - ${DRONE_TAG}
+    when:
+      event: tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum update -y && \
 
 EXPOSE 2181 2888 3888
 
-ENV ZK_VERSION 3.5.4-beta
+ENV ZK_VERSION 3.4.8
 RUN wget -q http://mirror.ox.ac.uk/sites/rsync.apache.org/zookeeper/zookeeper-${ZK_VERSION}/zookeeper-${ZK_VERSION}.tar.gz -O - | tar -xzf -; mv zookeeper-${ZK_VERSION} /zookeeper
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM quay.io/ukhomeofficedigital/centos-base:v0.2.0
+FROM quay.io/ukhomeofficedigital/centos-base:latest
 
-RUN yum upgrade -y -q; yum clean all
-RUN yum install -y -q java-headless tar wget; yum clean all
+RUN yum update -y && \
+  yum install -y java-headless tar wget && \
+  yum clean all
 
 EXPOSE 2181 2888 3888
 
 ENV ZK_VERSION 3.5.4-beta
 RUN wget -q http://mirror.ox.ac.uk/sites/rsync.apache.org/zookeeper/zookeeper-${ZK_VERSION}/zookeeper-${ZK_VERSION}.tar.gz -O - | tar -xzf -; mv zookeeper-${ZK_VERSION} /zookeeper
 
+
+USER 1000
 VOLUME /data
 WORKDIR /zookeeper
 COPY zoo.cfg /zookeeper/conf/zoo.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum update -y && \
 
 EXPOSE 2181 2888 3888
 
-ENV ZK_VERSION 3.4.8
+ENV ZK_VERSION 3.4.13
 RUN wget -q http://mirror.ox.ac.uk/sites/rsync.apache.org/zookeeper/zookeeper-${ZK_VERSION}/zookeeper-${ZK_VERSION}.tar.gz -O - | tar -xzf -; mv zookeeper-${ZK_VERSION} /zookeeper
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN yum install -y -q java-headless tar wget; yum clean all
 
 EXPOSE 2181 2888 3888
 
-ENV ZK_VERSION 3.5.1-alpha
+ENV ZK_VERSION 3.5.4-beta
 RUN wget -q http://mirror.ox.ac.uk/sites/rsync.apache.org/zookeeper/zookeeper-${ZK_VERSION}/zookeeper-${ZK_VERSION}.tar.gz -O - | tar -xzf -; mv zookeeper-${ZK_VERSION} /zookeeper
 
 VOLUME /data


### PR DESCRIPTION
converting to drone build to allow standup service container to be used in microservice component testing.

Ready to tag as release 3.4.8 (in line with ZK release) when merged into master